### PR TITLE
Now evaluating the Host variable from config-node and using it

### DIFF
--- a/fritz.html
+++ b/fritz.html
@@ -61,7 +61,7 @@
     <dt>Host
       <span class="property-type">string</span>
     </dt>
-    <dd>Host name or IP, defaults to <code>fritz.box</code>.</dd>
+    <dd>Host name or IP (with http://), defaults to <code>fritz.box</code>.</dd>
     <dt class="optional">Username
       <span class="property-type"string</span>
     </dt>

--- a/fritz.js
+++ b/fritz.js
@@ -138,7 +138,6 @@ module.exports = function(RED) {
 
         /** Obtain a session ID for API calls */
         node.login = function() {
-            console.log(node.options["url"]);
             return fritz.getSessionID(node.credentials.username || "", node.credentials.password, node.options)
             .then(function(sid) {
                 node.sid = sid;

--- a/fritz.js
+++ b/fritz.js
@@ -7,9 +7,13 @@ module.exports = function(RED) {
 	function Fritzbox( config) {
 		RED.nodes.createNode(this, config);
 		var node = this;
-
+        if(/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(config.host))
+        {
+            config.host = "http://" + config.host;
+        }
 		node.options = {
-			strictSSL: config.strictSSL
+			strictSSL: config.strictSSL,
+			url: config.host
 		};
 
         /** Login to the box and retrieve device list */

--- a/fritz.js
+++ b/fritz.js
@@ -9,7 +9,10 @@ module.exports = function(RED) {
 		var node = this;
         if(/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(config.host))
         {
-            config.host = "http://" + config.host;
+            if(!config.host.includes("http://")) {
+                config.host = "http://" + config.host;
+            }
+            
         }
 		node.options = {
 			strictSSL: config.strictSSL,
@@ -57,7 +60,7 @@ module.exports = function(RED) {
                 return;
             }
 
-            const ain = msg.ain || msg.topic;
+            const ain = msg.ain || msg.topic;
             const device = node.deviceList.find( function( device) {
                 return device.identifier.replace(/\s/g, '') == ain;
             });
@@ -135,6 +138,7 @@ module.exports = function(RED) {
 
         /** Obtain a session ID for API calls */
         node.login = function() {
+            console.log(node.options["url"]);
             return fritz.getSessionID(node.credentials.username || "", node.credentials.password, node.options)
             .then(function(sid) {
                 node.sid = sid;


### PR DESCRIPTION
Palette always used 'fritz.box' which can be a problem with multiple boxes in the network.
This should fix this. Now using config.host which is changed inside the fritz-api node.

Also added added a check if only a IP address is written inside fritz-api node. if the case we add 'http://' in front of the address